### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# Everything will be owned by the merra2-fluid-team team
+* @GEOS-ESM/merra2-fluid-team
+
+# Order is important; the last matching pattern takes the most
+# precedence. So add more specific patterns at the end.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-Clean up of initial setup by A. Collow
+
 ### Added
 
+- Added `CODEOWNERS` file
+
 ### Changed
+
+- Clean up of initial setup by A. Collow
 
 ### Fixed
 
 ### Removed
-Codes that are not needed for the monthly workflow.
+
+- Codes that are not needed for the monthly workflow.
+
 ### Deprecated
 


### PR DESCRIPTION
Closes #6 

This pull request adds a `.github/CODEOWNERS` file. It assigns all files to the @GEOS-ESM/merra2-fluid-team. Once this is in, I can update the settings to use it and require two approvers.

Note: At the moment the team is @ashiklom, @jardizzo, @nataliepthomas and @acollow (and myself). Per #6 there are two others that will be on the team once I have their GitHub IDs.