### PR TITLE
Bugfix/acollow/globallonfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed CDD constant 0 issue in computeRindices_seas.py (N. Thomas 11/22/24)
+- Removed minus sign for lon2 in the yaml section of the global and global land plots
 
 ### Removed
 

--- a/m2plots/time-series/latestyear_spaghetti_ncaregions_testylim.py
+++ b/m2plots/time-series/latestyear_spaghetti_ncaregions_testylim.py
@@ -124,7 +124,7 @@ global:
   lat1: -90
   lat2: 90
   lon1: -180
-  lon2: -179.375
+  lon2: 179.375
 globalland:
   region: 'Global Land'
   regionshortname: 'globalland'
@@ -133,7 +133,7 @@ globalland:
   lat1: -90
   lat2: 90
   lon1: -180
-  lon2: -179.375
+  lon2: 179.375
 
 
 """

--- a/m2plots/time-series/latestyear_spaghetti_windspeed.py
+++ b/m2plots/time-series/latestyear_spaghetti_windspeed.py
@@ -124,7 +124,7 @@ global:
   lat1: -90
   lat2: 90
   lon1: -180
-  lon2: -179.375
+  lon2: 179.375
 globalland:
   region: 'Global Land'
   regionshortname: 'globalland'
@@ -133,7 +133,7 @@ globalland:
   lat1: -90
   lat2: 90
   lon1: -180
-  lon2: -179.375
+  lon2: 179.375
 
 
 """


### PR DESCRIPTION
This corrects a bug with an erroneous minus sign in yaml section for global and global land plots.